### PR TITLE
ORT-GenAI notebook clarification

### DIFF
--- a/examples/onnxruntime-genai/ort-genai-dml-python.ipynb
+++ b/examples/onnxruntime-genai/ort-genai-dml-python.ipynb
@@ -13,7 +13,9 @@
    "id": "d712f8fd-7210-4041-86e6-3d27f3da9eb0",
    "metadata": {},
    "source": [
-    "Installing the correct package of onnxruntime-genai is important, as the suffix of the package shows which Execution Provider is included with the underlying ONNXRuntime framework. Here, we install the `onnxruntime-genai-directml` package so we can execute models through the DirectML Execution Provider."
+    "Installing the correct package of onnxruntime-genai is important, as the suffix of the package shows which Execution Provider is included with the underlying ONNXRuntime framework. Here, we install the `onnxruntime-genai-directml` package so we can execute models through the DirectML Execution Provider.\n",
+    "\n",
+    "**Note: The DirectML Execution Provider stems from DirectX, and thus is only available on Windows systems.**"
    ]
   },
   {


### PR DESCRIPTION
Add clarification in ORT-GenAI notebook that the DirectML EP is only compatible with Windows systems.